### PR TITLE
FIX: check if post exists

### DIFF
--- a/javascripts/discourse/components/short-share-link.js
+++ b/javascripts/discourse/components/short-share-link.js
@@ -41,7 +41,7 @@ export default class ShortShareLink extends Component {
   }
 
   get postSegment() {
-    return this.args.post.post_number > 1
+    return this.args.post?.post_number > 1
       ? `/${this.args.post.post_number}`
       : "";
   }


### PR DESCRIPTION
The post isn't always available in the share modal, when sharing the topic for example. 